### PR TITLE
Honor scriptLocation parameter

### DIFF
--- a/active_hours_scheduled_task.ps1
+++ b/active_hours_scheduled_task.ps1
@@ -66,5 +66,8 @@ if ($deleteTask) {
     Write-Output "Creating scheduled task: ${taskName}."
     Unblock-File -Path "${scriptLocation}"
     SCHTASKS.exe /Create /RU "SYSTEM" /TN "${taskName}" /xml "update_active_hours.xml"
+    if ($scriptLocation) {
+      SCHTASKS.exe /CHANGE /TN "${taskName}" /TR "Powershell.exe -ExecutionPolicy Unrestricted -File ${scriptLocation}"
+    }
   }
 }


### PR DESCRIPTION
The script location is hardcoded in the XML so we need to edit the task created with that XML to actually use the supplied scriptLocation.

I am sure there is a better way like replacing the location in the XML but powershell is not my strong suite so...